### PR TITLE
pipe stdin to subprocess

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -65,7 +65,7 @@ class BashOperator(BaseOperator):
                 logging.info("Running command: " + bash_command)
                 sp = Popen(
                     ['bash', fname],
-                    stdout=PIPE, stderr=STDOUT,
+                    stdout=PIPE, stderr=STDOUT, stdin=PIPE,
                     cwd=tmp_dir, env=self.env)
 
                 self.sp = sp


### PR DESCRIPTION
#This fixes issues with applications which rely on proper `stdin` and throw an error `Errno::EBADF: Bad file descriptor - 0` otherwise (at least on FreeBSD).