### PR TITLE
fix(exasol_hook): Make autocommit=False work

### DIFF
--- a/airflow/hooks/exasol_hook.py
+++ b/airflow/hooks/exasol_hook.py
@@ -142,6 +142,22 @@ class ExasolHook(DbApiHook):
                 getattr(self, self.conn_name_attr))
         conn.set_autocommit(autocommit)
 
+    def get_autocommit(self, conn):
+        """
+        Get autocommit setting for the provided connection.
+        Return True if autocommit is set.
+        Return False if autocommit is not set or set to False or conn
+        does not support autocommit.
+        :param conn: Connection to get autocommit setting from.
+        :type conn: connection object.
+        :return: connection autocommit setting.
+        :rtype bool.
+        """
+        autocommit = conn.attr.get('autocommit')
+        if autocommit is None:
+            autocommit = super(ExasolHook, self).get_autocommit(conn)
+        return autocommit
+
     @staticmethod
     def _serialize_cell(cell, conn):
         """

--- a/tests/hooks/test_exasol_hook.py
+++ b/tests/hooks/test_exasol_hook.py
@@ -87,9 +87,14 @@ class TestExasolHook(unittest.TestCase):
 
         self.conn.set_autocommit.assert_called_once_with(autocommit)
 
+    def test_get_autocommit(self):
+        setattr(self.conn, 'autocommit', True)
+        setattr(self.conn, 'attr', {'autocommit': False})
+        self.assertFalse(self.db_hook.get_autocommit(self.conn))
+
     def test_run_without_autocommit(self):
         sql = 'SQL'
-        setattr(self.conn, 'autocommit', False)
+        setattr(self.conn, 'attr', {'autocommit': False})
 
         # Default autocommit setting should be False.
         # Testing default autocommit value as well as run() behavior.


### PR DESCRIPTION
To determine if exasol has `autocommit` set we need to check the
`C.attr['autocommit']` and fallback on the old behavior. `C.autocommit`
is only set at creation of of the exasol connection and isn't updated when `C.set_autocommit()`
is run.